### PR TITLE
Issue #19: Volatility and Finisher meter mechanics now implemented

### DIFF
--- a/Finishers/Assets/Characters/Scripts/Systems/Combat/CombatSystem.cs
+++ b/Finishers/Assets/Characters/Scripts/Systems/Combat/CombatSystem.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 
 using Finisher.Characters.Systems.Strategies;
+using System;
 
 namespace Finisher.Characters.Systems
 {
@@ -39,11 +40,11 @@ namespace Finisher.Characters.Systems
 
         public delegate void HitEnemyDelegate(float amount);
         public event HitEnemyDelegate OnHitEnemy;
-        private void CallCombatSystemDealtDamageListeners(CoreCombatDamageSystem coreCombatDamageSystem)
+        private void CallCombatSystemDealtDamageListeners(float amount)
         {
             if (OnHitEnemy != null)
             {
-                OnHitEnemy(coreCombatDamageSystem.FinisherMeterGainAmount);
+                OnHitEnemy(amount);
             }
         }
 
@@ -66,6 +67,7 @@ namespace Finisher.Characters.Systems
 
         private float resetAttackTriggerTime = 0;
         private bool runningResetCR = false;
+        private int hitCounter;
 
         [HideInInspector] protected Animator animator;
         private AnimOverrideSetter animOverrideHandler;
@@ -97,6 +99,13 @@ namespace Finisher.Characters.Systems
                 smb.DodgeExitListeners += DodgeEnd;
             }
 
+            HealthSystem healthSystem = GetComponent<HealthSystem>();
+
+            if (healthSystem)
+            {
+                healthSystem.OnDamageTaken += resetHitCounter;
+            }
+
             IsDamageFrame = false;
         }
 
@@ -111,6 +120,13 @@ namespace Finisher.Characters.Systems
             foreach (DodgeSMB smb in dodgeSMBs)
             {
                 smb.DodgeExitListeners -= DodgeEnd;
+            }
+
+            HealthSystem healthSystem = GetComponent<HealthSystem>();
+
+            if (healthSystem)
+            {
+                healthSystem.OnDamageTaken -= resetHitCounter;
             }
         }
 
@@ -220,14 +236,43 @@ namespace Finisher.Characters.Systems
         {
             if (CurrentAttackType == AttackType.LightBlade)
             {
+                float finisherMeterGain = lightAttackDamageSystem.FinisherMeterGainAmount;
+
+                finisherMeterGain = multiplyFinisherMeterGain(finisherMeterGain);
+                
                 lightAttackDamageSystem.HitCharacter(targetHealthSystem);
-                CallCombatSystemDealtDamageListeners(lightAttackDamageSystem);
+                CallCombatSystemDealtDamageListeners(finisherMeterGain);
             }
             else if (CurrentAttackType == AttackType.HeavyBlade)
             {
+                float finisherMeterGain = heavyAttackDamageSystem.FinisherMeterGainAmount;
+
+                finisherMeterGain = multiplyFinisherMeterGain(finisherMeterGain);
+
                 heavyAttackDamageSystem.HitCharacter(targetHealthSystem);
-                CallCombatSystemDealtDamageListeners(heavyAttackDamageSystem);
+                CallCombatSystemDealtDamageListeners(finisherMeterGain);
             }
+
+            if (gameObject.tag == "Player")
+            {
+                hitCounter++;
+                hitCounter = Mathf.Clamp(hitCounter, 0, 15);
+            }
+        }
+
+        private float multiplyFinisherMeterGain(float finisherMeterGain)
+        {
+            if (hitCounter > 5)
+            {
+                finisherMeterGain = finisherMeterGain * (1 + (.05f * (hitCounter - 5)));
+            }
+            
+            return finisherMeterGain;
+        }
+
+        private void resetHitCounter()
+        {
+            hitCounter = 0;
         }
 
         #endregion

--- a/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultCoreCombatHeavyDS.asset
+++ b/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultCoreCombatHeavyDS.asset
@@ -14,4 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseDamage: 20
   dealsKnockback: 1
-  finisherMeterGainAmount: 20
+  finisherMeterGainAmount: 10

--- a/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultCoreCombatLightDS.asset
+++ b/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultCoreCombatLightDS.asset
@@ -14,4 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseDamage: 10
   dealsKnockback: 1
-  finisherMeterGainAmount: 10
+  finisherMeterGainAmount: 5

--- a/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultFinisherCombatHeavyDS.asset
+++ b/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultFinisherCombatHeavyDS.asset
@@ -14,6 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseDamage: 20
   dealsKnockback: 1
-  knockbackRange: 0
-  particleSystem: {fileID: 0}
-  volatilityDamage: 20
+  volatilityDamage: 10

--- a/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultFinisherCombatLightDS.asset
+++ b/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/DefaultFinisherCombatLightDS.asset
@@ -14,6 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseDamage: 10
   dealsKnockback: 1
-  knockbackRange: 0
-  particleSystem: {fileID: 0}
-  volatilityDamage: 10
+  volatilityDamage: 5

--- a/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/Scripts/FinisherModeDamageSystem.cs
+++ b/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/Scripts/FinisherModeDamageSystem.cs
@@ -4,7 +4,7 @@ namespace Finisher.Characters.Systems.Strategies
 {
     public abstract class FinisherModeDamageSystem : DamageSystem
     {
-        [SerializeField] private float volatilityDamage = 10f;
+        [SerializeField] private float volatilityDamage = 5f;
 
         public override void HitCharacter(HealthSystem targetHealthSytem)
         {
@@ -14,7 +14,9 @@ namespace Finisher.Characters.Systems.Strategies
 
         protected void DealVolatilityDamage(HealthSystem targetHealthSystem)
         {
-            targetHealthSystem.DamageVolatility(volatilityDamage);
+            float newVolatilityDamage = volatilityDamage + ((volatilityDamage / 2) * ((1 - targetHealthSystem.GetHealthAsPercent()) * 2.5f));
+            targetHealthSystem.DamageVolatility(newVolatilityDamage);
+            Debug.Log(newVolatilityDamage);
         }
     }
 }

--- a/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/Scripts/FinisherModeDamageSystem.cs
+++ b/Finishers/Assets/Characters/Scripts/Systems/DamageStrategies/Scripts/FinisherModeDamageSystem.cs
@@ -16,7 +16,6 @@ namespace Finisher.Characters.Systems.Strategies
         {
             float newVolatilityDamage = volatilityDamage + ((volatilityDamage / 2) * ((1 - targetHealthSystem.GetHealthAsPercent()) * 2.5f));
             targetHealthSystem.DamageVolatility(newVolatilityDamage);
-            Debug.Log(newVolatilityDamage);
         }
     }
 }

--- a/Finishers/Assets/Characters/Scripts/Systems/Health/HealthSystem.cs
+++ b/Finishers/Assets/Characters/Scripts/Systems/Health/HealthSystem.cs
@@ -26,6 +26,15 @@ namespace Finisher.Characters.Systems
                 OnKnockBack();
             }
         }
+        public delegate void TookDamage();
+        public event TookDamage OnDamageTaken;
+        private void CallDamageTakenEvent()
+        {
+            if (OnDamageTaken != null)
+            {
+                OnDamageTaken();
+            }
+        }
 
         #endregion
 
@@ -52,6 +61,7 @@ namespace Finisher.Characters.Systems
             if (characterState.Invulnerable) { return; }
 
             decreaseHealth(damage);
+            CallDamageTakenEvent();
 
             if (currentHealth <= 0)
             {


### PR DESCRIPTION
Enemies now take increased volatility damage based on their missing health. Player now gains a multiplier on finisher meter gain when scoring more than 5 consecutive hits on enemies without taking damage.